### PR TITLE
Gatherer: add a new --min-db-size-mb flag to ignore empty DBs

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -64,6 +64,7 @@ NB! Some variables influence multiple components. Command line parameters overri
 - **PW2_PING** Try to connect to all configured DB-s, report errors and then exit.
 - **PW2_INSTANCE_LEVEL_CACHE_MAX_SECONDS** Max allowed staleness for instance level metric data shared between DBs of an instance. Affects 'continuous' host types only. Set to 0 to disable. Default: 30
 - **PW2_DIRECT_OS_STATS** Extract OS related psutil statistics not via PL/Python wrappers but directly on host, i.e. assumes "push" setup. Default: off.
+- **PW2_MIN_DB_SIZE_MB** Smaller size DBs will be ignored and not monitored until they reach the threshold. Default: 0 (no size-based limiting).
 
 
 ## Web UI

--- a/pgwatch2/prom.go
+++ b/pgwatch2/prom.go
@@ -61,6 +61,10 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	for name, md := range monitoredDatabases {
 		setInstanceUpDownState(ch, md) // makes easier to differentiate between PG instance / machine  failures
 		// https://prometheus.io/docs/instrumenting/writing_exporters/#failed-scrapes
+		if !shouldDbBeMonitoredBasedOnCurrentState(md) {
+			log.Infof("[%s] Not scraping DB due to user set constraints like DB size or standby state", md.DBUniqueName)
+			continue
+		}
 		fetchedFromCacheCounts := make(map[string]int)
 
 		for metric, interval := range md.Metrics {


### PR DESCRIPTION
Sometimes un-interesting DBs cannot be excluded based on the name regex
so add another option. DB size is cached for 10min to not strain the DBs
too much